### PR TITLE
Correct typo in algs_rate.js

### DIFF
--- a/tests/algs_rate.js
+++ b/tests/algs_rate.js
@@ -50,5 +50,5 @@ assert.equal(net.learning_momentum, 123);
 
 // wrong momentum, change to NaN
 net.learning_momentum = 'hi!';
-assert(isNaN(net.learning_rate));
+assert(isNaN(net.learning_momentum));
 


### PR DESCRIPTION
Corrected a typo where the final test was testing learning_rate again, not learning_momentum.
