### PR TITLE
Add an "engines" property to warn node 0.11/0.12 users

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,7 @@
   "license"     : { "type"  : "WTFPL"
                   , "url"   : "http://www.wtfpl.net/txt/copying/" },
 
+  "engines"     : { "node" : "<0.11" },
+
   "gypfile"     : true
 }


### PR DESCRIPTION
As we know (#15), this package won’t work on node 0.11 and 0.12.

This small pull request adds an appropriate ```engines``` property in package.json to warn people which attempt to install it on these versions of node, saving them some googling after a build failure.

For example, on my machine this produces something like:
```
$ npm install ~/src/node-fann
npm WARN engine fann@0.2.4: wanted: {"node":"<0.11"} (current: {"node":"0.12.2","npm":"2.7.5"})

> fann@0.2.4 install /Users/gh/tmp/node_modules/fann
> node-gyp rebuild

…
```
This restriction should be removed once the 0.11 support is ready.